### PR TITLE
Remove conflicting python framework on MacOS

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,4 +31,7 @@ jobs:
         with:
           name: dldt
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Remove conflicting Python framework on MacOS
+        run: sudo rm -fr /Library/Frameworks/Python.framework
+        if: ${{ runner.os == 'macOS' }}
       - run: nix flake check --accept-flake-config


### PR DESCRIPTION
USD build picks up that one instead of Nixpkgs' one. Should be fixed at the nix build file level, but good enough for now.