### PR TITLE
Delay package update 2 hours after lock file update

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -2,7 +2,7 @@ name: update-packages
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
+    - cron: "0 2 * * 0" # runs weekly on Sunday at 02:00
 jobs:
   update-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should leave enough time for the first PR to be processed.