### PR TITLE
visrtx: Disable NEURAL primitives

### DIFF
--- a/pkgs/visrtx/package.nix
+++ b/pkgs/visrtx/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     (cmakeBool "VISRTX_PRECOMPILE_SHADERS" false)
 
     (cmakeFeature "OPTIX_FETCH_VERSION" "${versions.majorMinor nvidia-optix.version}")
-    (cmakeBool "VISRTX_ENABLE_NEURAL" true)
+    (cmakeBool "VISRTX_ENABLE_NEURAL" false)
   ];
 
   patches = [


### PR DESCRIPTION
Shader compilation never ends with this feature on.