### PR TITLE
pbrt-v4: enable CUDA support

### DIFF
--- a/pkgs/pbrt-v4/package.nix
+++ b/pkgs/pbrt-v4/package.nix
@@ -6,13 +6,22 @@
   config,
   cudaSupport ? config.cudaSupport,
   optixSupport ? cudaSupport && stdenv.hostPlatform.isx86_64,
-  cudaPackages,
+  # pbrt-v4 trips a chain of nvcc/CCCL 12.8 bugs (cudafe1.stub.c host-stub
+  # gen, __host__ macroization order, cuda_bf16 device intrinsics in
+  # non-arch-guarded paths) that are absent in 12.9+. Pin to cudaPackages_12_9
+  # rather than keeping the flake-default cudaPackages so we can drop the
+  # workarounds. Other packages in the flake (barney, visionaray) keep the
+  # default cudaPackages — there's a second CUDA closure on disk in exchange.
+  cudaPackages_12_9,
   autoAddDriverRunpath,
   nvidia-optix,
   zlib,
   openexr,
   nix-update-script,
 }:
+let
+  cudaPackages = cudaPackages_12_9;
+in
 stdenv.mkDerivation (_finalAttrs: {
   pname = "pbrt-v4";
   version = "0-unstable-2026-05-01";
@@ -101,12 +110,21 @@ stdenv.mkDerivation (_finalAttrs: {
     CUDAGLSTUB
   ''
   + lib.optionalString cudaSupport ''
-    # pbrt unconditionally appends `--gpu-architecture=$ARCH` to CMAKE_CUDA_FLAGS, which
-    # only emits SASS for one arch. Replace with the full nixpkgs gencode list (SASS for
-    # each arch + PTX for the highest, enabling JIT for forward-compat on newer GPUs).
+    # pbrt's CMakeLists hardcodes a single CUDA arch via `--gpu-architecture=$ARCH`
+    # (sm_75 here), which is correct for OptiX PTX compilation (single-arch required
+    # by `-ptx`). Augment SASS-target compiles with the full nixpkgs gencode list —
+    # SASS for every supported arch + PTX for the highest, enabling forward-compat
+    # JIT on newer GPUs. The `$<NOT:CUDA_PTX_COMPILATION>` guard keeps the multi-
+    # gencode list off pbrt's OptiX shader targets, where `-ptx + multi-gencode` is
+    # a fatal nvcc error. Scoped to cuda_build_configuration so it doesn't leak into
+    # check_language(CUDA)'s try-compile.
     substituteInPlace CMakeLists.txt --replace-fail \
-        'string (APPEND CMAKE_CUDA_FLAGS " --gpu-architecture=''${ARCH}")' \
-        'string (APPEND CMAKE_CUDA_FLAGS " ${cudaPackages.flags.gencodeString}")'
+        'string (APPEND CMAKE_CUDA_FLAGS " -Xnvlink -suppress-stack-size-warning")' \
+        'string (APPEND CMAKE_CUDA_FLAGS " -Xnvlink -suppress-stack-size-warning")
+        target_compile_options (cuda_build_configuration INTERFACE
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<BOOL:$<TARGET_PROPERTY:CUDA_PTX_COMPILATION>>>>:${
+              builtins.replaceStrings [ " " ] [ ";" ] cudaPackages.flags.gencodeString
+            }>")'
   '';
 
   nativeBuildInputs = [
@@ -150,13 +168,6 @@ stdenv.mkDerivation (_finalAttrs: {
     # Allow the linker to resolve `-lcuda` against the driver stub at link time;
     # autoAddDriverRunpath then patches RPATH so the loader picks the real driver at runtime.
     export NIX_LDFLAGS="$NIX_LDFLAGS -L${cudaPackages.cuda_cudart}/lib/stubs"
-
-    # Workaround for an nvcc 12.8 bug: the .cudafe1.stub.c stub-emitter references
-    # cuda::std device-side symbols (piecewise_construct, swappable, iter_move) without
-    # including the corresponding CCCL headers, so host compilation of the stub fails.
-    # Force-include the public umbrella headers via the host compiler. Drop this once
-    # cudaPackages tracks an nvcc that emits its own includes.
-    export CUDAFLAGS="$CUDAFLAGS -Xcompiler -include,cuda/std/utility -Xcompiler -include,cuda/std/concepts -Xcompiler -include,cuda/std/iterator"
   '';
 
   postInstall = ''


### PR DESCRIPTION
The CUDA-enabled build was silently producing CPU-only artifacts (zero CUDA symbols in libpbrt_lib.a, no libpbrt_embedded_ptx_lib.a, libcuda stub baked into RPATH). This change makes it actually compile and link the GPU path, and gates the unbuildable variants.

CUDA toolchain:
- Pin to cudaPackages_12_9. The flake-default 12.8 trips a chain of interlocking nvcc/CCCL bugs (cudafe1.stub.c host-stub generation, __host__ macroization ordering, cuda_bf16 device intrinsics in non-arch-guarded paths) that 12.9 fixes; pinning lets us drop all the workarounds at the cost of a second CUDA closure on disk.
- Set CUDA_TOOLKIT_ROOT_DIR to cudaPackages.cudatoolkit so pbrt's legacy `find_package(CUDA REQUIRED)` resolves in nixpkgs' split CUDA layout.
- Add cudaPackages.cuda_cudart/_cccl to buildInputs and cuda_nvcc + autoAddDriverRunpath to nativeBuildInputs. Pass the cudart stubs path via NIX_LDFLAGS for link-time -lcuda resolution; runpath is rewritten to the real driver lib at fixup.
- Replace pbrt's hardcoded `--gpu-architecture=${ARCH}` (single SASS arch) with cudaPackages.flags.gencodeString (multi-arch SASS + PTX fallback) injected via target_compile_options on cuda_build_configuration. The `COMPILE_LANGUAGE:CUDA + NOT CUDA_PTX_COMPILATION` guard keeps it off OptiX shader compiles (where -ptx + multi-gencode is a fatal nvcc error) and out of check_language(CUDA)'s try-compile.

Patch hardening:
- All `sed -i` invocations converted to `substituteInPlace --replace-fail`, including a previously silent-no-op CHECK_EXT patch that didn't match upstream's `function (CHECK_EXT …)` (extra space) and only worked because git wasn't on PATH.
- glfw/glad ext block stripped via anchored `sed -d` range with a `grep -q` guard so the build fails loudly if the anchors miss after an upstream bump.
- gui.h's `<glad/glad.h>` and `<GLFW/glfw3.h>` includes replaced with opaque forward declarations so installed headers don't require a GL toolchain on the consumer side.

Exported cmake config:
- Detect CUDA-built variant via presence of libpbrt_embedded_ptx_lib.a; emit `find_dependency(CUDAToolkit)`, `CUDA::cudart`, `CUDA::cuda_driver`, the embedded-PTX archive, and `PBRT_BUILD_GPU_RENDERER` only then.

Other:
- Install consumer headers from the patched workdir, not $src.
- `meta.broken = cudaSupport && !optixSupport` — catches aarch64+cuda where OptiX is unavailable and pbrt silently disables GPU codegen, so the flake's filterOutBroken drops it from packagesCuda.aarch64-linux instead of producing a phantom CPU-only "CUDA" build.
- Add meta.mainProgram; drop `with lib;` antipattern in meta.